### PR TITLE
Fix for issue where "END" in a key causes premature end in MC-GET.

### DIFF
--- a/cl-memcached.lisp
+++ b/cl-memcached.lisp
@@ -253,7 +253,7 @@ response :
     (write-sequence (server-request (append (list "get") keys-list)) s)
     (force-output s)
     (loop for x = (read-line-from-binary-stream s)
-       until (search "END" x :test #'string-equal)
+       until (string-equal "END" x)
        collect (let* ((status-line (split-sequence:split-sequence #\Space x))
 		      (key (second status-line))
 		      (flags (third status-line))
@@ -393,7 +393,7 @@ response :
     (loop for line = (read-line-from-binary-stream s)
        collect (let ((param (split-sequence:split-sequence #\Space line)))
 		 (cons (second param) (third param)))
-       until (search "END" line  :test #'string-equal))))
+       until (string-equal "END" line))))
 
 
 


### PR DESCRIPTION
I found a major issue where keys which contain the word "END" were prematurely triggering MC-GET to finish. I fixed this by replacing the end test condition to a direct string comparison.

The use of search seems like it was legacy code, as it does character comparison using string-equal.
